### PR TITLE
`dist/use-interval-ts.esm.js` in main field of package.json does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lib",
     "interval"
   ],
-  "module": "dist/use-interval-ts.esm.js",
+  "module": "dist/interval.esm.js",
   "size-limit": [
     {
       "path": "dist/use-interval-ts.cjs.production.min.js",


### PR DESCRIPTION
Ran into this issue when building an app that utilizes the `@use-it` package:

```
> 57 |   "module": "dist/use-interval-ts.esm.js",
>    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ './dist/use-interval-ts.esm.js' does not exist, did you mean './dist/interval.esm.js'?'
```